### PR TITLE
Enhance Atom feeds

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -45,14 +45,13 @@ DATE_FORMATS = {
 }
 
 FEED_ALL_ATOM = "feeds/all.atom.xml"
-#FEED_ALL_RSS = "feeds/all.xml"
 CATEGORY_FEED_ATOM = "feeds/{slug}.atom.xml"
+TAG_FEED_ATOM = "feeds/{slug}.atom.xml"
 TRANSLATION_FEED_ATOM = None
 AUTHOR_FEED_ATOM = None
-AUTHOR_FEED_RSS = None
-GITHUB_CORNER_URL = "https://github.com/sullivanmatt/bugalert"
-
 USE_FOLDER_AS_CATEGORY = False
+
+GITHUB_CORNER_URL = "https://github.com/sullivanmatt/bugalert"
 MAIN_MENU = True
 HOME_HIDE_TAGS = True
 
@@ -91,6 +90,7 @@ MENUITEMS = (
     ("My Subscriptions", "/content/pages/my-subscriptions.html", ""),
     ("Categories", "/categories.html", "nomobile"),
     ("Tags", "/tags.html", "nomobile"),
+    ("Atom (RSS)", "/content/pages/atom.html", "nomobile"),
 )
 
 CC_LICENSE = {

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -482,14 +482,6 @@
       {% for title, link, css_class in MENUITEMS %}
       <a class="{{ css_class }} " href="{{ link }}">{{ _(title) }}</a>
       {% endfor %}
-
-      {% if FEED_ALL_ATOM %}
-      <a class="nomobile" href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}">{{ _('Atom') }}</a>
-      {% endif %}
-
-      {% if FEED_ALL_RSS %}
-      <a class="nomobile" href="{{ FEED_DOMAIN }}/{{ FEED_ALL_RSS }}">{{ _('RSS') }}</a>
-      {% endif %}
     </nav>
     {% endif %}
 


### PR DESCRIPTION
Enabling Atom feeds for tags, and manually adding a link to a new page (will be PR'd into the content repo) that lists all Atom feeds.