### PR TITLE
Work around Ubuntu bug that causes mktime issues when using TZs that observe DST

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -17,7 +17,8 @@ ROBOTS = "index, follow"
 THEME = "./theme"
 PATH = "../content"
 OUTPUT_PATH = "../output/"
-TIMEZONE = "America/New_York"
+#TIMEZONE = "America/New_York" # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001774
+TIMEZONE = "Etc/UTC"
 
 DISABLE_URL_HASH = True
 DISPLAY_PAGES_ON_MENU = False


### PR DESCRIPTION
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001774

Early on in the project I decided to use New York as the project's display timezone, simply because I assumed the majority of the users may end up being based in the US. Thankfully for our project, it has seen global embrace, so this is no longer necessary anyway.

Setting Pelican to use UTC, which I have verified does work around this issue.